### PR TITLE
Add logic to include wordpress error details in ember-data error object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ yarn-error.log
 testem.log
 .DS_Store
 
+.vscode
+
 # ember-try
 .node_modules.ember-try/
 bower.json.ember-try

--- a/addon/adapters/wordpress.js
+++ b/addon/adapters/wordpress.js
@@ -22,9 +22,19 @@ export default DS.RESTAdapter.extend({
 				totalPages: getHeader(headers, 'X-WP-TotalPages')
 			};
 			payload.meta = meta;
-		}
-		return this._super(status, headers, payload, requestData);
-	},
+    }
+
+    if (this.isInvalid(status, headers, payload)) {
+      payload.errors = [payload];
+    }
+
+    return this._super(status, headers, payload, requestData);
+
+  },
+
+  isInvalid(status) {
+    return status === 422 || status === 400;
+  },
 
   pathForType: function(modelName) {
     modelName = modelName.replace('wordpress/', '');


### PR DESCRIPTION
Fix structure of ember-wordpress error payload so that the wordpress error details will be parsed properly into the ember-data error model.